### PR TITLE
Fix : 컨텐츠를 각 구조의 자료구조 수만큼 설계 #14

### DIFF
--- a/src/data/linearStructure.js
+++ b/src/data/linearStructure.js
@@ -2,28 +2,9 @@ export const linearStructure = {
 	name: "linearStructure",
 	areas: [
 		{
-			name: "분기될 자료구조명(ex연결리스트)",
+			name: "자료구조명",
 			skills: [
 
-				{
-					name: "분기될 자료구조명(ex연결리스트)",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					},
-
-					skills: [
-						{
-							name: "분기된 자료구조명(ex단순연결리스트)",
-							description: {
-								text: "text",
-								links: [
-									["name", "html"],]}
-						},
-					]
-				},
 
 				{
 					name: "자료구조명",
@@ -58,8 +39,32 @@ export const linearStructure = {
 								links: [
 									["name", "html"],]}
 						},
+						{
+							name: "분기된 자료구조명(ex단순연결리스트)",
+							description: {
+								text: "text",
+								links: [
+									["name", "html"],]}
+						},
+						{
+							name: "분기된 자료구조명(ex단순연결리스트)",
+							description: {
+								text: "text",
+								links: [
+									["name", "html"],]}
+						},
 					]
 				},
+
+				
+			
+			]
+		},
+		{
+			name: "자료구조명",
+			skills: [
+
+				
 
 				{
 					name: "자료구조명",
@@ -74,28 +79,27 @@ export const linearStructure = {
 			]
 		},
 		{
-			name: "분기될 자료구조명(ex연결리스트)",
+			name: "자료구조명",
 			skills: [
 
+				
+
 				{
-					name: "분기될 자료구조명(ex연결리스트)",
+					name: "자료구조명",
 					description: {
 						text: "text",
 						links: [
 							["name", "html"],
 						]
-					},
-
-					skills: [
-						{
-							name: "분기된 자료구조명(ex단순연결리스트)",
-							description: {
-								text: "text",
-								links: [
-									["name", "html"],]}
-						},
-					]
+					}
 				},
+			
+			]
+		},
+		{
+			name: "자료구조명",
+			skills: [
+
 
 				{
 					name: "자료구조명",

--- a/src/data/nonLinearStructure.js
+++ b/src/data/nonLinearStructure.js
@@ -1,6 +1,7 @@
 export const nonLinearStructure = {
 	name: "nonLinearStructure",
 	areas: [
+		
 		{
 			name: "분기될 자료구조명(ex연결리스트)",
 			skills: [
@@ -22,18 +23,17 @@ export const nonLinearStructure = {
 								links: [
 									["name", "html"],]}
 						},
+						{
+							name: "분기된 자료구조명(ex단순연결리스트)",
+							description: {
+								text: "text",
+								links: [
+									["name", "html"],]}
+						},
 					]
 				},
 
-				{
-					name: "자료구조명",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					}
-				},
+	
 			
 			]
 		},
@@ -58,35 +58,6 @@ export const nonLinearStructure = {
 								links: [
 									["name", "html"],]}
 						},
-					]
-				},
-
-				{
-					name: "자료구조명",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					}
-				},
-			
-			]
-		},
-		{
-			name: "분기될 자료구조명(ex연결리스트)",
-			skills: [
-
-				{
-					name: "분기될 자료구조명(ex연결리스트)",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					},
-
-					skills: [
 						{
 							name: "분기된 자료구조명(ex단순연결리스트)",
 							description: {
@@ -97,15 +68,7 @@ export const nonLinearStructure = {
 					]
 				},
 
-				{
-					name: "자료구조명",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					}
-				},
+			
 			
 			]
 		},

--- a/src/data/simpleStructure.js
+++ b/src/data/simpleStructure.js
@@ -2,28 +2,8 @@ export const simpleStructure = {
 	name: "simpleStructure",
 	areas: [
 		{
-			name: "분기될 자료구조명(ex연결리스트)",
+			name: "자료구조명",
 			skills: [
-
-				{
-					name: "분기될 자료구조명(ex연결리스트)",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					},
-
-					skills: [
-						{
-							name: "분기된 자료구조명(ex단순연결리스트)",
-							description: {
-								text: "text",
-								links: [
-									["name", "html"],]}
-						},
-					]
-				},
 
 				{
 					name: "자료구조명",
@@ -38,28 +18,9 @@ export const simpleStructure = {
 			]
 		},
 		{
-			name: "분기될 자료구조명(ex연결리스트)",
+			name: "자료구조명",
 			skills: [
 
-				{
-					name: "분기될 자료구조명(ex연결리스트)",
-					description: {
-						text: "text",
-						links: [
-							["name", "html"],
-						]
-					},
-
-					skills: [
-						{
-							name: "분기된 자료구조명(ex단순연결리스트)",
-							description: {
-								text: "text",
-								links: [
-									["name", "html"],]}
-						},
-					]
-				},
 
 				{
 					name: "자료구조명",
@@ -74,28 +35,25 @@ export const simpleStructure = {
 			]
 		},
 		{
-			name: "분기될 자료구조명(ex연결리스트)",
+			name: "자료구조명",
 			skills: [
 
+
 				{
-					name: "분기될 자료구조명(ex연결리스트)",
+					name: "자료구조명",
 					description: {
 						text: "text",
 						links: [
 							["name", "html"],
 						]
-					},
-
-					skills: [
-						{
-							name: "분기된 자료구조명(ex단순연결리스트)",
-							description: {
-								text: "text",
-								links: [
-									["name", "html"],]}
-						},
-					]
+					}
 				},
+			
+			]
+		},
+		{
+			name: "자료구조명",
+			skills: [
 
 				{
 					name: "자료구조명",


### PR DESCRIPTION
## 어떤 목적의 풀리퀘스트 입니까?

각 구조의 컨텐츠 수를 수정하여, 같은 파일을 수정하는 상황에서 충돌을 방지하기 위함입니다.
만일 컨텐츠 수를 미리 설계해놓지 않으면 협업시 다른 이의 코드를 건들이게 됩니다.

## 어떤 기능을 추가하거나 수정 하였습니까?

각 구조에 해당하는 js 파일의 컨텐츠 수를 데이터 구조도에 맞게 수정하였습니다.

## 참고 자료 

![데이터구조도](https://user-images.githubusercontent.com/93778192/186085122-4b408aec-7ca0-4f47-97bc-0a7a179972e7.png)

