### PR TITLE
Fix : 홈페이지 상단의 아이콘 및 링크 수정 #48

### DIFF
--- a/generate-blueprint.js
+++ b/generate-blueprint.js
@@ -159,43 +159,26 @@ writeFileSync(FILE_NAME, `<h1 align="center">Web Skills</h1>
 {{ template:toc }}
 </details>
 
-## FAQ
+### 이 프로젝트는 무엇을 위한 것인가
+'Datastructure Master'는 컴퓨터공학 전공자와 비전공자를 포함한 자료구조를 학습하고자 하는 학생들의 자료구조에 대한 이해 능력을 증진하기 위한 프로젝트임
+'Datastructure Master' 프로젝트를 통해 자료구조의 정의, 개념과 같은 기초 지식을 쌓고, 그 지식을 프로그래밍 언어로 구현함으로써 자료구조 학습을 단계적으로 진행할 수 있도록 도움을 줌
+또한 'Datastructure Master' 프로젝트는 정의, 개념, 구현을 한 페이지에 제공함으로써 자료구조 지식에 관한 접근 용이성을 편리하게 함
 
-### What is Web Skills?
+### 어떤 문제를 해결할 수 있는가?
+자료구조의 올바른 정의와 개념을 정립함
+자료구조의 구현 방법 및 활용 방법을 정립함
+자료구조를 각종 프로그래밍 언어로 구현해봄으로써 프로그래밍 실력 향상에 기여함
+다양한 예제 문제를 통해서 자료구조에 대한 이해도를 자각함
+프로그래밍의 기반이 되는 자료구조를 학습함으로써 컴퓨터 과학에서 효율적인 접근 및 수정을 가능케 하는 자료의 조직, 관리, 저장 가능
 
-Web Skills is a visual overview of useful skills to learn as a web developer. It is useful for people who just started learning about web development and for people who have been in the field for years and want to learn new things. As a beginner, I would encourage you not to see this website as the definitive list of what you need to know but as an example of what you can learn and where you can start. The skills are arranged in chronological order based on what learning path I recommend you to take but feel free to jump around freely.
+### 왜 이 프로젝트가 유용한가
+알기 쉬운 UI, 링크를 모아둠으로써 접근성 향상
+유튜브 미디어 시각 자료를 활용함으로써 이해 증진 활용에 효과적 
 
-### How did you choose the skills?
-		
-The skills are derived from a combination of 10 years of experience, a bachelor in software engineering and what I personally find to be the most useful to know on a day-to-day basis. Therefore, you'll notice that it's missing a lot of things. For example, I am not a PHP developer - because of this, PHP is not included. If you were a PHP developer, this overview would probably look a lot different.
-
-### How can I support you?
-
-I am spending my spare time building Web Skills for free because I want to help people get into web development. My motivation comes from people finding Web Skills useful, so if you like the project feel free to support me in any way you like! For example, you are more than welcome to become a [stargazer](https://github.com/andreasbm/web-skills/stargazers), share Web Skills with your friends and followers or create blog articles linking to Web Skills. If you want to, it will absolutely make my day if you [support me with a cup of coffee](https://www.buymeacoffee.com/AndreasMehlsen)! <3
-
-### How can I get involved?
-
-You are welcome to get involved in any way you like. If you want to, you can go to the [issues page](https://github.com/andreasbm/web-skills/issues) and help me fix the spelling, fix issues or suggest some new features. Any involvement is highly appreciated!
-
-### How can I keep track of what skills I know?
-
-If you scroll to the bottom of the page, you will find a button that says "Sign in with Google". If you click this button and sign in, you will be able to mark skills as completed.
-
-### I am overwhelmed! Help me!
-
-I totally understand if you are a bit overwhelmed by the amount of skills on the page – but I can assure you that this overview includes much, much more than most people will ever need to know. My main goal is to provide a visual overview of web development and make people hungry for learning more. One of the things I absolute love about being a developer is learning new skills. I think it is amazing to be in a field where you can do what you do for a lifetime and still learn something new! People cannot be an expert in every skill on this page so try to find what excites you the most and become really good at that.
-
-### Why haven't you included XYZ Technology?
-
-The skills are based on what I personally find to be the most useful on a day-to-day basis. If you think something really important is missing, you can always suggest it on the [issues page](https://github.com/andreasbm/web-skills/issues).
-
-### What does the "experimental" banner mean?
-
-When a skill is described as experimental, it means that the technology is immature and currently in the process of being added to the Web platform (or considered for addition). Think carefully before you start using experimental technology in any kind of production project. The definition used in Web Skills is based on the excellent definition used on [MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#Experimental). You are very welcome to open an issue if you see a skill you believe should be marked as "experimental" or have the banner removed.
-
-### How can I get in contact with you?
-
-Reach out to me on Twitter at [@AndreasMehlsen](https://twitter.com/AndreasMehlsen) or take a look at [my website](https://andreasbm.github.io) if you want to learn more about what other projects I'm working on.
+### 어떤 사람들이 이 프로젝트를 사용하면 좋은가
+컴퓨터 과학을 전공하는 전공자
+프로그래밍 언어를 독학하고자 하는 비전공자
+자료구조에 대한 기초 지식을 쌓아 지식 기반을 탄탄히 하고자 하는 학생
 
 ${collectionsMarkdown}
 {{ template:contributors }}

--- a/src/app.js
+++ b/src/app.js
@@ -710,13 +710,6 @@ export class App extends LitElement {
 					<ws-button aria-label="Share website" @click="${this.share}" title="Open share menu">
 						<ws-icon .template="${shareIconTemplate}"></ws-icon>
 					</ws-button>
-					<a aria-label="Open author" href="https://andreasbm.github.io" target="_blank" rel="noopener" title="Say hi">
-						<ws-icon hoverable .template="${andreasIconTemplate}" ></ws-icon>
-					</a>
-					<a id="coffee" aria-label="Buy coffee" href="https://www.buymeacoffee.com/AndreasMehlsen" rel="noopener" title="Support me <3" target="_blank">
-						<svg id="steam" viewBox="0 0 250 327" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" stroke="currentColor" stroke-width="41"><path d="M119.563 265.584c-27-20.344-43.822-41.277-50.465-62.8-6.643-21.522-7.9-45.48-3.771-71.875M170.152 189.86c12.91-24.089 19.139-47.393 18.685-69.913-.453-22.52-5.297-42.502-14.53-59.947"/></g></svg>
-						<ws-icon hoverable .template="${coffeeIconTemplate}"></ws-icon>
-					</a>
 				</div>
 			</header>
 			<main id="collections">

--- a/src/app.js
+++ b/src/app.js
@@ -710,6 +710,9 @@ export class App extends LitElement {
 					<ws-button aria-label="Share website" @click="${this.share}" title="Open share menu">
 						<ws-icon .template="${shareIconTemplate}"></ws-icon>
 					</ws-button>
+					<a aria-label="Open author" href="https://andreasbm.github.io" target="_blank" rel="noopener" title="Say hi">
+						<ws-icon hoverable .template="${andreasIconTemplate}" ></ws-icon>
+					</a>
 				</div>
 			</header>
 			<main id="collections">


### PR DESCRIPTION
## 어떤 목적의 풀리퀘스트 입니까?
웹 페이지 화면의 아이콘과 링크를 수정한 Pull Request 입니다.
## 어떤 기능을 추가하거나 수정 하였습니까?
기부 아이콘과 깃허브 페이지로 이동하는 아이콘을 삭제하고 도움말 아이콘의 내용을 수정하였습니다.
## 참고 자료 
![image](https://user-images.githubusercontent.com/45378755/186573029-f0e98bae-182f-4b57-864a-7b29ecdf1a41.png)

